### PR TITLE
:sparkles: creates sponsorship package page

### DIFF
--- a/code-of-conduct/index.html
+++ b/code-of-conduct/index.html
@@ -1,61 +1,75 @@
 <!doctype html>
-<html class="no-js" lang="en">
+<html lang="en">
 <head>
-	<meta charset="utf-8">
-	<meta http-equiv="x-ua-compatible" content="ie=edge">
-	<title>Code of Conduct - Ela Conf 2015</title>
-	<meta name="description" content="Ela Conference works to eliminate the existing diversity gap in tech by empowering more individuals identifying as a woman to be leaders and take action through practical training and thoughtful mentorships.">
-	<meta name="keywords" content="web design,design,designer,developer,front-end,tech,technology,women,female,girls,conference,empower,web,women in tech">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<meta name="google-site-verification" content="fwQlP4L8TVoaRJctoltAtyp9zrdfeOkm1NNSAVENMdk" />
-	<link rel="shortcut icon" href="/images/elafav.png" type="image/x-icon">
-	<link rel="icon" href="/images/elafav.png" type="image/x-icon">
-	<link type="text/css" rel="stylesheet" href="/css/normalize.css" />
-	<link type="text/css" rel="stylesheet" href="/css/elaconf.css" />
-	<link href='http://fonts.googleapis.com/css?family=Strait|Open+Sans:400,400italic,700' rel='stylesheet' type='text/css'>
+  <meta charset="utf-8">
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <title>Code of Conduct &bull; Ela Conf 2015</title>
+  <meta name="description" content="Ela Conference works to eliminate the existing diversity gap in tech by empowering more individuals identifying as a woman (18+) in a way that is significant to them to be leaders and take action through practical training and thoughtful mentorships">
+  <meta name="keywords" content="web design,design,designer,developer,front-end,tech,technology,women,female,girls,conference,empower,web,women in tech">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="google-site-verification" content="fwQlP4L8TVoaRJctoltAtyp9zrdfeOkm1NNSAVENMdk" />
+  <link rel="shortcut icon" href="/images/elafav.png" type="image/x-icon">
+  <link rel="icon" href="/images/elafav.png" type="image/x-icon">
+  <link type="text/css" rel="stylesheet" href="/css/normalize.css" />
+  <link type="text/css" rel="stylesheet" href="/css/elaconf.css" />
+  <link href='http://fonts.googleapis.com/css?family=Strait|Open+Sans:400,400italic,700' rel='stylesheet' type='text/css'>
+  <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
 </head>
 <body>
-	<div class="page page-conduct">
-		<!-- ///////////////////////////////////////////////////// -->
-		<!-- Header -->
-		<!-- ///////////////////////////////////////////////////// -->
-		<header class="header-small">
-			<a href="../"><img class="ela-logo" src="/images/elalogo.svg" alt="Ela Conf logo in basic shapes" /></a>
-		</header>
-		<section class="main">
-			<h1>Code of Conduct</h1>
-			<p>All attendees, speakers, sponsors and volunteers at our events and throughout a mentorship are required to agree with the following code of conduct. Organizers will enforce this code throughout the events and for the duration of a mentorship. We are expecting cooperation from all participants to help ensure a safe environment for everybody.</p>
-			<h2>Need Help?</h2>
-			<p>The Elanor Community email is <a href="mailto:hello@elanor.community">hello@elanor.community</a> and the Ela Conf email is <a href="mailto:hello@elaconf.com">hello@elaconf.com</a>. Relevant phone numbers will be shared prior to each event and during the mentorship matching phase.</p>
-			<h2>The Quick Version</h2>
-			<p>Our events, including Ela Conf, and programs are dedicated to providing a harassment-free experiences for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, or religion (or lack thereof). We do not tolerate harassment of participants in any form. Sexual language and imagery is not appropriate for any event, including conferences, talks, workshops, parties, Twitter and other online media, throughout the duration of a mentorship. Participants violating these rules may be sanctioned or expelled from the Elanor Community <em>without a refund</em> (when applicable) at the discretion of the group organizers.</p>
-			<h2>The Less Quick Version</h2>
-			<p>Harassment includes offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.</p>
-			<p>Participants asked to stop any harassing behavior are expected to comply immediately.</p>
-			<p>Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualised images, activities, or other material. At events and conferences, booth staff (including volunteers) should not use sexualised clothing/uniforms/costumes, or otherwise create a sexualised environment.</p>
-			<p>If a participant engages in harassing behavior, the organizers may take any action they deem appropriate, including warning the offender or expulsion from the event/conference with no refund.</p>
-			<p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of staff immediately. Staff will be introduced on the site as well as prior to any event.</p>
-			<p>Staff will be happy to help participants contact venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance and participation.</p>
-			<p>We expect participants, volunteers, mentors, and mentees to follow these rules at all Elanor Community events and programs, including conferences, workshops, social events, and throughout the duration of a mentorship relationship.</p>
-			<p><em>This Code of Conduct was adapted from <a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy"> The Ada Initiative</a></em></p>
-			<p><a class="button" href="../docs/code-of-conduct.pdf">Download the Code of Conduct</a></p>
-		</section>
+  <div class="page page-inner page-code-of-conduct">
+    <header class="header-small">
+  <a href="../"><img class="ela-logo" src="/images/elalogo.svg" alt="Ela Conf logo in basic shapes" /></a>
+</header>  
+    <section class="main">
+      <h1>Code of Conduct</h1>
+      <p>All attendees, speakers, sponsors and volunteers at our events and throughout a mentorship are required to agree with the following code of conduct. Organizers will enforce this code throughout the events and for the duration of a mentorship. We are expecting cooperation from all participants to help ensure a safe environment for everybody.</p>
 
-		<!-- ///////////////////////////////////////////////////// -->
-		<!-- Footer -->
-		<!-- ///////////////////////////////////////////////////// -->
-		<footer id="footer">
-			<div class="grid">
-				<div class="two-thirds">
-					<p>Twitter <a href="https://www.twitter.com/elaconf">@elaconf</a><br>Email <a href="mailto:hello@elaconf.com">hello@elaconf.com</a></p>
-				</div>
-				<div class="third">
-					<p>Our newsletter</p>
-					<a href="https://tinyletter.com/elaletters" class="button button-compact button-newsletter">Sign up</a>
-				</div>
-			</div>
-		</footer>
+<h2 id="need-help">Need Help?</h2>
 
-	</div>
+<p>The Elanor Community email is <a href="&#109;&#097;&#105;&#108;&#116;&#111;:&#104;&#101;&#108;&#108;&#111;&#064;&#101;&#108;&#097;&#110;&#111;&#114;&#046;&#099;&#111;&#109;&#109;&#117;&#110;&#105;&#116;&#121;">&#104;&#101;&#108;&#108;&#111;&#064;&#101;&#108;&#097;&#110;&#111;&#114;&#046;&#099;&#111;&#109;&#109;&#117;&#110;&#105;&#116;&#121;</a> and the Ela Conf email is <a href="&#109;&#097;&#105;&#108;&#116;&#111;:&#104;&#101;&#108;&#108;&#111;&#064;&#101;&#108;&#097;&#099;&#111;&#110;&#102;&#046;&#099;&#111;&#109;">&#104;&#101;&#108;&#108;&#111;&#064;&#101;&#108;&#097;&#099;&#111;&#110;&#102;&#046;&#099;&#111;&#109;</a>. Relevant phone numbers will be shared prior to each event and during the mentorship matching phase.</p>
+
+<h2 id="the-quick-version">The Quick Version</h2>
+
+<p>Our events, including Ela Conf, and programs are dedicated to providing a harassment-free experiences for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, or religion (or lack thereof). We do not tolerate harassment of participants in any form. Sexual language and imagery is not appropriate for any event, including conferences, talks, workshops, parties, Twitter and other online media, throughout the duration of a mentorship. Participants violating these rules may be sanctioned or expelled from the Elanor Community <em>without a refund</em> (when applicable) at the discretion of the group organizers.</p>
+
+<h2 id="the-less-quick-version">The Less Quick Version</h2>
+
+<p>Harassment includes offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.</p>
+
+<p>Participants asked to stop any harassing behavior are expected to comply immediately.</p>
+
+<p>Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualised images, activities, or other material. At events and conferences, booth staff (including volunteers) should not use sexualised clothing/uniforms/costumes, or otherwise create a sexualised environment.</p>
+
+<p>If a participant engages in harassing behavior, the organizers may take any action they deem appropriate, including warning the offender or expulsion from the event/conference with no refund.</p>
+
+<p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of staff immediately. Staff will be introduced on the site as well as prior to any event.</p>
+
+<p>Staff will be happy to help participants contact venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance and participation.</p>
+
+<p>We expect participants, volunteers, mentors, and mentees to follow these rules at all Elanor Community events and programs, including conferences, workshops, social events, and throughout the duration of a mentorship relationship.</p>
+
+<p><em>This Code of Conduct was adapted from <a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy">The Ada Initiative</a></em></p>
+
+<p><a href="../docs/code-of-conduct.pdf">Download the Code of Conduct</a></p>
+
+    </section>
+    <footer id="footer">
+  <div class="grid">
+    <div class="two-thirds">
+      <p>Twitter: <a href="https://www.twitter.com/elaconf">@elaconf</a><br>Email: <a href="mailto:hello@elaconf.com">hello@elaconf.com</a></p>
+    </div>
+    <div class="third">
+      <p>Our Newsletter:</p>
+      <a href="https://tinyletter.com/elaletters" class="button button-compact button-newsletter">Sign up</a>
+    </div>
+  </div>
+</footer>
+  </div>
+<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.0.0-alpha1/jquery.min.js"></script>
+<script>
+$("h2,h3").each(function(){
+  $(this).wrap("<a href='#"+$(this).attr('id')+"'></a>");
+});
+</script>
 </body>
 </html>

--- a/css/elaconf.css
+++ b/css/elaconf.css
@@ -138,7 +138,6 @@ section:nth-of-type(even) a {
 .page-sponsorship-packages ul {
   list-style: disc;
   padding-left: 2em;
-  font-size: 14px;
   margin: 2em auto 4em;
 }
 
@@ -147,13 +146,12 @@ section:nth-of-type(even) a {
 }
   
 
-
 hr {
   border-style: solid;
-  border-width: .2em 0 0 0;
+  border-width: .1em 0 0 0;
   border-color: #231947 transparent transparent;
-  margin: 2em auto 3em;
   max-width: 750px;
+  margin-bottom: 3em;
 }
 
 /* section: organizers */

--- a/css/elaconf.css
+++ b/css/elaconf.css
@@ -131,10 +131,30 @@ section:nth-of-type(even) a {
   color: #231947;
 }
 
-.page-conduct .main h2 {
+.page-code-of-conduct .main h2 {
   color: #231947;
 }
 
+.page-sponsorship-packages ul {
+  list-style: disc;
+  padding-left: 2em;
+  font-size: 14px;
+  margin: 2em auto 4em;
+}
+
+.page-sponsorship-packages li {
+  margin-bottom: .25em;
+}
+  
+
+
+hr {
+  border-style: solid;
+  border-width: .2em 0 0 0;
+  border-color: #231947 transparent transparent;
+  margin: 2em auto 3em;
+  max-width: 750px;
+}
 
 /* section: organizers */
 
@@ -236,6 +256,20 @@ footer a:hover {
 
 .button:hover {
   text-decoration: none;
+}
+
+.main {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.main h1,
+.main h2,
+.main h3,
+.main p,
+.main ul {
+  text-align: left;
+  max-width: none;
 }
 
 .main .button:hover {

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
   <title>Ela Conf 2015</title>
-  <meta name="description" content="Ela Conference works to eliminate the existing diversity gap in tech by empowering more individuals identifying as a woman to be leaders and take action through practical training and thoughtful mentorships.">
+  <meta name="description" content="Ela Conference works to eliminate the existing diversity gap in tech by empowering more individuals identifying as a woman (18+) in a way that is significant to them to be leaders and take action through practical training and thoughtful mentorships">
   <meta name="keywords" content="web design,design,designer,developer,front-end,tech,technology,women,female,girls,conference,empower,web,women in tech">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="google-site-verification" content="fwQlP4L8TVoaRJctoltAtyp9zrdfeOkm1NNSAVENMdk" />
@@ -15,104 +15,95 @@
   <link href='http://fonts.googleapis.com/css?family=Strait|Open+Sans:400,400italic,700' rel='stylesheet' type='text/css'>
   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
 </head>
-
 <body>
-
   <div class="page">
-    <!-- ///////////////////////////////////////////////////// -->
-    <!-- Header -->
-    <!-- ///////////////////////////////////////////////////// -->
     <header class="primary-header" id="ela-conf">
-      <img class="ela-logo" src="images/elalogo.svg" alt="Ela Conf logo in basic shapes" />
-      <p>Philadelphia, Pennsylvania<br>October 23 &amp; 24, 2015</p>
-      <!--<a href="#" class="button">Buy ticket</a>-->
-    </header>
-
+  <img class="ela-logo" src="images/elalogo.svg" alt="Ela Conf logo in basic shapes" />
+  <p>Philadelphia, Pennsylvania<br>October 23 &amp; 24, 2015</p>
+  <!--<a href="#" class="button">Buy ticket</a>-->
+</header>  
     <!-- ///////////////////////////////////////////////////// -->
-    <!-- About -->
-    <!-- ///////////////////////////////////////////////////// -->
-    <section class="section-about" id="about">
-      <h1>About</h1>
-      <h2><span class="about-stand-for">E</span>mpowerment. <span class="about-stand-for">L</span>eadership. <span class="about-stand-for">A</span>ction.</h2>
-      <p>Ela Conference works to eliminate the existing diversity gap in tech by empowering more individuals identifying as a woman (18+) in a way that is significant to them to be leaders and take action through practical training and thoughtful mentorships.</p>
-      <p>We are a not-for-profit event with a goal to create a safe, supportive, inspiring and comfortable <em>community</em> for women to gain the confidence needed to become leaders, open source contributors, speakers, and teachers in the world of tech.</p>
-      <p>Our <a href="code-of-conduct/">code of conduct</a> is the heart of our event. Please <a href="mailto:hello@elaconf.com">reach out to us</a> if you have any concerns or there is something you would like to see included that isn’t. </p>
-    </section>
-    <!-- ///////////////////////////////////////////////////// -->
-    <!-- Agenda -->
-    <!-- ///////////////////////////////////////////////////// -->
-    <section class="section-agenda" id="agenda">
-      <h1>Agenda</h1>
-      <p>Ela Conf will kick off with a meet and greet on Friday evening, October 23. The conference itself will be held on Saturday the 24. There will be food, childcare, small breakout sessions, panel discussions, and presentations.</p>
-      <p><em>The complete agenda will be available to view soon!</em></p>
-    </section>
-    <!-- ///////////////////////////////////////////////////// -->
-    <!-- Speaker spotlight -->
-    <!-- ///////////////////////////////////////////////////// -->
-    <section class="section-speaker-spotlight" id="speakers">
-      <h1>Speaker Spotlight</h1>
-      <p><em>This information is coming soon!</em></p>
-    </section>
-    <!-- ///////////////////////////////////////////////////// -->
-    <!-- Sponsor spotlight -->
-    <!-- ///////////////////////////////////////////////////// -->
-    <section class="section-sponsor-spotlight" id="sponsors">
-      <h1>Sponsor Spotlight</h1>
-      <p>If your company or organization is interested in sponsoring Ela Conf (hey, thanks so much!) we would love to <a href="mailto:hello@elaconf.com">hear from you</a>.</p>
-      <p><em>Take a look at <a href="https://docs.google.com/document/d/1iZqNH1Udl1SvE20GKez7yQfNgMwxKGtz6EzBIxmBVvw/pub">our sponsorship package here</a>.</em></p>
-      <!--<p>You can also take a peek at our <a href="">sponsorship packages</a>--><!--or choose to simply <a href="">make a donation</a>--></p>
-    </section>
-    <!-- ///////////////////////////////////////////////////// -->
-    <!-- Venue -->
-    <!-- ///////////////////////////////////////////////////// -->
-    <section class="section-venue" id="venue">
-      <h1>Venue</h1>
-      <p><em>This information is coming soon!</em></p>
-    </section>
-    <!-- ///////////////////////////////////////////////////// -->
-    <!-- Organizers -->
-    <!-- ///////////////////////////////////////////////////// -->
-    <section class="section-organizers" id="organizers">
-      <h1>Organizers</h1>
-      <div class="organizer">
-        <img class="organizer-img" src="/images/organizers/joni.png" alt="Joni" />
-        <p class="organizer-bio"><a href="https://twitter.com/JoniTrythall">Joni Trythall</a> is a freelance web designer, teacher, and author. Joni's passion for design and teaching began when she wrote and illustrated a children's book. Since then she has been obsessed with learning about using graphics on the web and writing about everything in the process. She currently lives deep in the quiet Philadelphia suburbs with her husband and three year old son.</p>
-      </div>
-      <div class="organizer">
-        <img class="organizer-img" src="/images/organizers/leann.png" alt="LeAnn" />
-        <p class="organizer-bio"><a href="https://twitter.com/_leekinney">LeeAnn Kinney</a> is a front-end developer living in Philadelphia. She is a web accessibility advocate, events coordinator for <a href="http://www.meetup.com/Girl-Develop-It-Philadelphia/">Girl Develop It</a> Philly, and co-organizer of <a href="http://ladyhacks.org/">LadyHacks</a> and the <a href="http://phillywomenintech.com/">Philly Women in Tech Summit</a>. </p>
-      </div>
-      <div class="organizer">
-        <img class="organizer-img" src="/images/organizers/katy.png" alt="Katy" />
-        <p class="organizer-bio"><a href="https://twitter.com/katydecorah">Katy DeCorah</a> is a tinkerer, explainer, and helper at <a href="https://www.mapbox.com/">Mapbox</a>. She loves playing with CSS and building front-end tools. In her free time she enjoys getting lost in a side project, the woods, or an X-Files marathon. Katy lives and works from home in Albany, New York.</p>
-      </div>
-      <div class="organizer">
-        <img class="organizer-img" src="/images/organizers/dominique.png" alt="Dominique" />
-        <p class="organizer-bio"><a href="https://twitter.com/deeclarkesays">Dominique Clarke</a> is a code newbie who loves exploring the intersection between tech and civic engagement. She is obsessed with Philadelphia neighborhoods and has spent the past year building community through <a href="http://phillyfellows.org/ ">Philly Fellows</a> while taking coding classes with Girl Develop It. She likes her cheesesteak whiz with and will fight to defend her preference.</p>
-      </div>
-    </section>
-    <!-- ///////////////////////////////////////////////////// -->
-    <!-- Reasons to Attend -->
-    <!-- ///////////////////////////////////////////////////// -->
-    <section class="section-reasons" id="reasons-to-attend">
-      <h1>Convince Your Boss</h1>
-      <ul>
-        <li>Learn valuable new tech and communication skills</li>
-        <li>Get inspired and motivated</li>
-        <li>Gain confidence to embrace and share your talents</li>
-        <li>Help hire talented, local women</li>
-        <li>Develop new ways of thinking and approaching the existing diversity gap in tech</li>
-        <li>Network with your peers</li>
-        <li>Become part of a lasting local community</li>
-        <li>Learn how to take action, become a leader, and create your own opportunties</li>
-        <li>Become part of a lasting, meaningful mentorship</li>
-      </ul>
-      <!--<em><p>Grab a neat <a href="">PDF of these fantastic points</a>.</p></em>-->
-    </section>
+<!-- About -->
 <!-- ///////////////////////////////////////////////////// -->
-<!-- Footer -->
+<section class="section-about" id="about">
+  <h1>About</h1>
+  <h2><span class="about-stand-for">E</span>mpowerment. <span class="about-stand-for">L</span>eadership. <span class="about-stand-for">A</span>ction.</h2>
+  <p>.</p>
+  <p>We are a not-for-profit event with a goal to create a safe, supportive, inspiring and comfortable <em>community</em> for women to gain the confidence needed to become leaders, open source contributors, speakers, and teachers in the world of tech.</p>
+  <p>Our <a href="code-of-conduct/">code of conduct</a> is the heart of our event. Please <a href="mailto:hello@elaconf.com">reach out to us</a> if you have any concerns or there is something you would like to see included that isn’t. </p>
+</section>
 <!-- ///////////////////////////////////////////////////// -->
-<footer id="footer">
+<!-- Agenda -->
+<!-- ///////////////////////////////////////////////////// -->
+<section class="section-agenda" id="agenda">
+  <h1>Agenda</h1>
+  <p>Ela Conf will kick off with a meet and greet on Friday evening, October 23. The conference itself will be held on Saturday the 24. There will be food, childcare, small breakout sessions, panel discussions, and presentations.</p>
+  <p><em>The complete agenda will be available to view soon!</em></p>
+</section>
+<!-- ///////////////////////////////////////////////////// -->
+<!-- Speaker spotlight -->
+<!-- ///////////////////////////////////////////////////// -->
+<section class="section-speaker-spotlight" id="speakers">
+  <h1>Speaker Spotlight</h1>
+  <p><em>This information is coming soon!</em></p>
+</section>
+<!-- ///////////////////////////////////////////////////// -->
+<!-- Sponsor spotlight -->
+<!-- ///////////////////////////////////////////////////// -->
+<section class="section-sponsor-spotlight" id="sponsors">
+  <h1>Sponsor Spotlight</h1>
+  <p>If your company or organization is interested in sponsoring Ela Conf (hey, thanks so much!) we would love to <a href="mailto:hello@elaconf.com">hear from you</a>.</p>
+  <p><em>Take a look at <a href="/sponsorship-packages/">our sponsorship package here</a>.</em></p>
+  <!--<p>You can also take a peek at our <a href="">sponsorship packages</a>--><!--or choose to simply <a href="">make a donation</a>--></p>
+</section>
+<!-- ///////////////////////////////////////////////////// -->
+<!-- Venue -->
+<!-- ///////////////////////////////////////////////////// -->
+<section class="section-venue" id="venue">
+  <h1>Venue</h1>
+  <p><em>This information is coming soon!</em></p>
+</section>
+<!-- ///////////////////////////////////////////////////// -->
+<!-- Organizers -->
+<!-- ///////////////////////////////////////////////////// -->
+<section class="section-organizers" id="organizers">
+  <h1>Organizers</h1>
+  <div class="organizer">
+    <img class="organizer-img" src="/images/organizers/joni.png" alt="Joni" />
+    <p class="organizer-bio"><a href="https://twitter.com/JoniTrythall">Joni Trythall</a> is a freelance web designer, teacher, and author. Joni's passion for design and teaching began when she wrote and illustrated a children's book. Since then she has been obsessed with learning about using graphics on the web and writing about everything in the process. She currently lives deep in the quiet Philadelphia suburbs with her husband and three year old son.</p>
+  </div>
+  <div class="organizer">
+    <img class="organizer-img" src="/images/organizers/leann.png" alt="LeAnn" />
+    <p class="organizer-bio"><a href="https://twitter.com/_leekinney">LeeAnn Kinney</a> is a front-end developer living in Philadelphia. She is a web accessibility advocate, events coordinator for <a href="http://www.meetup.com/Girl-Develop-It-Philadelphia/">Girl Develop It</a> Philly, and co-organizer of <a href="http://ladyhacks.org/">LadyHacks</a> and the <a href="http://phillywomenintech.com/">Philly Women in Tech Summit</a>. </p>
+  </div>
+  <div class="organizer">
+    <img class="organizer-img" src="/images/organizers/katy.png" alt="Katy" />
+    <p class="organizer-bio"><a href="https://twitter.com/katydecorah">Katy DeCorah</a> is a tinkerer, explainer, and helper at <a href="https://www.mapbox.com/">Mapbox</a>. She loves playing with CSS and building front-end tools. In her free time she enjoys getting lost in a side project, the woods, or an X-Files marathon. Katy lives and works from home in Albany, New York.</p>
+  </div>
+  <div class="organizer">
+    <img class="organizer-img" src="/images/organizers/dominique.png" alt="Dominique" />
+    <p class="organizer-bio"><a href="https://twitter.com/deeclarkesays">Dominique Clarke</a> is a code newbie who loves exploring the intersection between tech and civic engagement. She is obsessed with Philadelphia neighborhoods and has spent the past year building community through <a href="http://phillyfellows.org/ ">Philly Fellows</a> while taking coding classes with Girl Develop It. She likes her cheesesteak whiz with and will fight to defend her preference.</p>
+  </div>
+</section>
+<!-- ///////////////////////////////////////////////////// -->
+<!-- Reasons to Attend -->
+<!-- ///////////////////////////////////////////////////// -->
+<section class="section-reasons" id="reasons-to-attend">
+  <h1>Convince Your Boss</h1>
+  <ul>
+    <li>Learn valuable new tech and communication skills</li>
+    <li>Get inspired and motivated</li>
+    <li>Gain confidence to embrace and share your talents</li>
+    <li>Help hire talented, local women</li>
+    <li>Develop new ways of thinking and approaching the existing diversity gap in tech</li>
+    <li>Network with your peers</li>
+    <li>Become part of a lasting local community</li>
+    <li>Learn how to take action, become a leader, and create your own opportunties</li>
+    <li>Become part of a lasting, meaningful mentorship</li>
+  </ul>
+  <!--<em><p>Grab a neat <a href="">PDF of these fantastic points</a>.</p></em>-->
+</section>
+    <footer id="footer">
   <div class="grid">
     <div class="two-thirds">
       <p>Twitter: <a href="https://www.twitter.com/elaconf">@elaconf</a><br>Email: <a href="mailto:hello@elaconf.com">hello@elaconf.com</a></p>
@@ -123,6 +114,6 @@
     </div>
   </div>
 </footer>
-</div>
+  </div>
 </body>
 </html>

--- a/sponsorship-packages/index.html
+++ b/sponsorship-packages/index.html
@@ -1,48 +1,172 @@
 <!doctype html>
-<html class="no-js" lang="en">
+<html lang="en">
 <head>
-	<meta charset="utf-8">
-	<meta http-equiv="x-ua-compatible" content="ie=edge">
-	<title>Sponsorship Packages - Ela Conf 2015</title>
-	<meta name="description" content="Ela Conference works to eliminate the existing diversity gap in tech by empowering more individuals identifying as a woman to be leaders and take action through practical training and thoughtful mentorships.">
-	<meta name="keywords" content="web design,design,designer,developer,front-end,tech,technology,women,female,girls,conference,empower,web,women in tech">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<meta name="google-site-verification" content="fwQlP4L8TVoaRJctoltAtyp9zrdfeOkm1NNSAVENMdk" />
-	<link rel="shortcut icon" href="/images/elafav.png" type="image/x-icon">
-	<link rel="icon" href="/images/elafav.png" type="image/x-icon">
-	<link type="text/css" rel="stylesheet" href="/css/normalize.css" />
-	<link type="text/css" rel="stylesheet" href="/css/elaconf.css" />
-	<link href='http://fonts.googleapis.com/css?family=Strait|Open+Sans:400,400italic,700' rel='stylesheet' type='text/css'>
+  <meta charset="utf-8">
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <title>Sponsorship Packages &bull; Ela Conf 2015</title>
+  <meta name="description" content="Ela Conference works to eliminate the existing diversity gap in tech by empowering more individuals identifying as a woman (18+) in a way that is significant to them to be leaders and take action through practical training and thoughtful mentorships">
+  <meta name="keywords" content="web design,design,designer,developer,front-end,tech,technology,women,female,girls,conference,empower,web,women in tech">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="google-site-verification" content="fwQlP4L8TVoaRJctoltAtyp9zrdfeOkm1NNSAVENMdk" />
+  <link rel="shortcut icon" href="/images/elafav.png" type="image/x-icon">
+  <link rel="icon" href="/images/elafav.png" type="image/x-icon">
+  <link type="text/css" rel="stylesheet" href="/css/normalize.css" />
+  <link type="text/css" rel="stylesheet" href="/css/elaconf.css" />
+  <link href='http://fonts.googleapis.com/css?family=Strait|Open+Sans:400,400italic,700' rel='stylesheet' type='text/css'>
+  <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
 </head>
 <body>
-	<div class="page page-sponsorship">
-		<!-- ///////////////////////////////////////////////////// -->
-		<!-- Header -->
-		<!-- ///////////////////////////////////////////////////// -->
-		<header class="header-small">
-			<a href="../"><img class="ela-logo" src="/images/elalogo.svg" alt="Ela Conf logo in basic shapes" /></a>
-		</header>
-		<section class="main">
-			<h1>Sponsorship packages</h1>
+  <div class="page page-inner page-sponsorship-packages">
+    <header class="header-small">
+  <a href="../"><img class="ela-logo" src="/images/elalogo.svg" alt="Ela Conf logo in basic shapes" /></a>
+</header>  
+    <section class="main">
+      <h1>Sponsorship Packages</h1>
+      <p>To sponsor, please email <a href="&#109;&#097;&#105;&#108;&#116;&#111;:&#104;&#101;&#108;&#108;&#111;&#064;&#101;&#108;&#097;&#099;&#111;&#110;&#102;&#046;&#099;&#111;&#109;">&#104;&#101;&#108;&#108;&#111;&#064;&#101;&#108;&#097;&#099;&#111;&#110;&#102;&#046;&#099;&#111;&#109;</a>. <a href="https://docs.google.com/document/u/1/d/1iZqNH1Udl1SvE20GKez7yQfNgMwxKGtz6EzBIxmBVvw/pub">Download the sponsorship packages document.</a></p>
 
-			<p><a class="button" href="../docs/code-of-conduct.pdf">Download the Sponsorship Packages</a></p>
-		</section>
+<h2 id="support-levels">Support Levels</h2>
 
-		<!-- ///////////////////////////////////////////////////// -->
-		<!-- Footer -->
-		<!-- ///////////////////////////////////////////////////// -->
-		<footer id="footer">
-			<div class="grid">
-				<div class="two-thirds">
-					<p>Twitter <a href="https://www.twitter.com/elaconf">@elaconf</a><br>Email <a href="mailto:hello@elaconf.com">hello@elaconf.com</a></p>
-				</div>
-				<div class="third">
-					<p>Our newsletter</p>
-					<a href="https://tinyletter.com/elaletters" class="button button-compact button-newsletter">Sign up</a>
-				</div>
-			</div>
-		</footer>
+<h3 id="individual-supporter-300">Individual Supporter ($300)</h3>
 
-	</div>
+<ul>
+  <li>ONE (1) ticket to the conference</li>
+  <li>Individual name or company name included on slideshow, related event materials</li>
+</ul>
+
+<h3 id="company-sponsor-500">Company Sponsor ($500)</h3>
+
+<ul>
+  <li>Up to TWO (2) tickets to the conference</li>
+  <li>Your swag in a giveaway bag for all guests</li>
+  <li>Thank you mention on the <a href="https://www.twitter.com/elaconf">@elaconf</a> Twitter account during the lead up to the conference</li>
+  <li>Individual name or company name included on slideshow</li>
+  <li>Up to TWO (2) job listings on conference slideshow and included in post-event email blast</li>
+</ul>
+
+<h3 id="community-builder-1000">Community Builder ($1,000)</h3>
+
+<ul>
+  <li>Up to FOUR (4) tickets to the event</li>
+  <li>Your swag in a giveaway bag for all guests</li>
+  <li>THREE (3) mentions on the <a href="https://www.twitter.com/elaconf">@elaconf</a> Twitter account during the lead up to the conference</li>
+  <li>Company name included on included on slideshow</li>
+  <li>Up to FOUR (4) job listings on conference slideshow and included in post-event email blast</li>
+  <li>Logo/link on <a href="http://elaconf.com">elaconf.com</a></li>
+  <li>Verbal recognition during the conference announcements</li>
+</ul>
+
+<h3 id="ecosystem-supporter-2500">Ecosystem Supporter ($2,500)</h3>
+
+<ul>
+  <li>Up to SIX (6) tickets to the event</li>
+  <li>Your swag in a giveaway bag for all guests</li>
+  <li>SIX (6) mentions on the <a href="https://www.twitter.com/elaconf">@elaconf</a> Twitter account during lead up and post-event</li>
+  <li>Company name included on included on slideshow</li>
+  <li>Up to SIX (6) job listings on conference slideshow and included in post-event email blast</li>
+  <li>Verbal recognition during the conference announcements</li>
+  <li>ONE (1) guest company sponsored spot in our popular newsletter: Ela Letters</li>
+</ul>
+
+<h3 id="women-in-tech-signature-sponsor--negotiable">Women in Tech Signature Sponsor — (Negotiable)</h3>
+
+<ul>
+  <li>Your company name among the highest level sponsors of this event</li>
+  <li>Up to TWELVE (12) tickets to the event</li>
+  <li>Your swag in a giveaway bag for all guests</li>
+  <li>Mentions on the <a href="https://www.twitter.com/elaconf">@elaconf</a> Twitter account during lead up and post-event every time the conference is mentioned</li>
+  <li>Company name included on slideshow</li>
+  <li>Up to TWELVE (12) job listings on conference slideshow; multiple slides</li>
+  <li>THREE-minute verbal welcome opportunity in conference announcements</li>
+  <li>Company name on all signage, handouts, and related events materials</li>
+  <li>Open ELA conf on Friday evening, by welcoming participants (10 minutes maximum)</li>
+  <li>TWO (2) guest company sponsored spots in our popular newsletter: Ela Letters</li>
+</ul>
+
+<h2 id="other-sponsorship-opportunities">Other Sponsorship Opportunities</h2>
+
+<h3 id="scholarship-sponsor-200attendee">Scholarship Sponsor ($200/attendee)</h3>
+
+<ul>
+  <li>Help someone get to the conference who may not be able to handle the financial burden</li>
+  <li>Support our diversity scholarship to help ensure we have the most welcoming, inclusive event possible</li>
+</ul>
+
+<h3 id="swag-bag-sponsor-500">Swag Bag Sponsor ($500)</h3>
+
+<ul>
+  <li>Sponsor-defined logos/placement on 150+ giveaway (reusable/canvas) bags, plus [optional] swag within (provided by sponsor)</li>
+  <li>Mentioned whenever the swag bags are mentioned in writing and verbally</li>
+  <li>Logo on conference slideshow</li>
+</ul>
+
+<h3 id="lanyard-sponsor-600">Lanyard Sponsor ($600)</h3>
+
+<ul>
+  <li>Sponsor-defined logos/placement on 150+ lanyards, plus [optional] swag within swag bags (provided by sponsor)</li>
+  <li>Mentioned whenever the lanyards are mentioned in writing and verbally</li>
+  <li>Logo on conference slideshow</li>
+</ul>
+
+<h3 id="t-shirt-sponsor-800">T-Shirt Sponsor ($800)</h3>
+
+<ul>
+  <li>Mentioned whenever the t-shirts are mentioned in writing and verbally</li>
+  <li>TWO (2) mentions on the <a href="https://www.twitter.com/elaconf">@elaconf</a> Twitter account during the lead up to the party</li>
+  <li>Individual name or company name included on included on slideshow</li>
+</ul>
+
+<h3 id="breakfast-sponsor-1000">Breakfast Sponsor ($1000)</h3>
+
+<ul>
+  <li>Company representatives at breakfast</li>
+  <li>THREE (3) mentions on the <a href="https://www.twitter.com/elaconf">@elaconf</a> Twitter account during the lead up to the conference</li>
+  <li>Company name included on included on slideshow</li>
+  <li>Logo/link on <a href="http://elaconf.com">elaconf.com</a></li>
+  <li>Verbal recognition during the conference announcements</li>
+</ul>
+
+<h3 id="lunch-sponsor-2500">Lunch Sponsor ($2500)</h3>
+
+<ul>
+  <li>Company representatives at breakfast</li>
+  <li>FIVE (5) mentions on the <a href="https://www.twitter.com/elaconf">@elaconf</a> Twitter account during the lead up to the conference</li>
+  <li>Company name included on included on slideshow</li>
+  <li>Logo/link on <a href="http://elaconf.com">elaconf.com</a></li>
+  <li>Verbal recognition during the conference announcements</li>
+</ul>
+
+<hr />
+
+<p>Have another idea for sponsorships, such as some sort of in-kind exchange? We’d love to hear from you. For inquiries and more information regarding sponsorship opportunities, please email <a href="&#109;&#097;&#105;&#108;&#116;&#111;:&#104;&#101;&#108;&#108;&#111;&#064;&#101;&#108;&#097;&#099;&#111;&#110;&#102;&#046;&#099;&#111;&#109;">&#104;&#101;&#108;&#108;&#111;&#064;&#101;&#108;&#097;&#099;&#111;&#110;&#102;&#046;&#099;&#111;&#109;</a></p>
+
+<h3 id="notes-on-sponsorship-benefits">Notes on Sponsorship Benefits</h3>
+
+<ul>
+  <li>Tickets as part of sponsorship must identify as a woman in a way that is significant to them. </li>
+  <li>The slideshow will be shown at the beginning and end of day as well as during breakfast and lunch.</li>
+  <li>Social media mentions will take place before, during, and up to 3 months after the conference. </li>
+</ul>
+
+<p><em>This sponsorship one-pager has been forked from Geekadelphia’s Philly Geek Awards one-pager, so thank you!</em></p>
+
+    </section>
+    <footer id="footer">
+  <div class="grid">
+    <div class="two-thirds">
+      <p>Twitter: <a href="https://www.twitter.com/elaconf">@elaconf</a><br>Email: <a href="mailto:hello@elaconf.com">hello@elaconf.com</a></p>
+    </div>
+    <div class="third">
+      <p>Our Newsletter:</p>
+      <a href="https://tinyletter.com/elaletters" class="button button-compact button-newsletter">Sign up</a>
+    </div>
+  </div>
+</footer>
+  </div>
+<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.0.0-alpha1/jquery.min.js"></script>
+<script>
+$("h2,h3").each(function(){
+  $(this).wrap("<a href='#"+$(this).attr('id')+"'></a>");
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
@jonitrythall @leekinney @dominiqueclarke The google drive version of the sponsorship packages format is a little difficult to read on wider screens. I created a page with the same content on the site, but I still link to the document at the top.

Here’s what the page looks like. The h2/h3 automatically generate links so one can click on them to generate a link to share that sponsorship level:

![page](https://cloud.githubusercontent.com/assets/2180540/8689302/c6bc3180-2a73-11e5-8da3-cd29b40d9ebe.png)


Any objections?