### PR TITLE
new tickets names and descriptions

### DIFF
--- a/_sass/_table.scss
+++ b/_sass/_table.scss
@@ -26,7 +26,7 @@ table th {
   font-size: inherit;
   margin: 0;
   overflow: visible; /*to make ths where the title is really long work*/
-
+  
   @include breakpoint(medium) {
     padding: 0.75em 1em; /* cell padding */
     border-left: 1px solid $light;/*  inner column border */
@@ -67,19 +67,7 @@ table thead th {
   font-weight: bold;
 }
 
-/*
-table td {
-border-bottom: 1px solid $light;
+td.text-right {
+  @include breakpoint(medium) { min-width: 117px; }
+  @include breakpoint(small) { text-align: left; }
 }
-
-table tbody > tr:last-child > td {
-border-bottom-width: 0;
-}
-*/
-
-
-  td.text-right {
-    @include breakpoint(medium) { min-width: 117px; }
-      @include breakpoint(small) { text-align: left; }
-  }
-

--- a/_sass/_type.scss
+++ b/_sass/_type.scss
@@ -2,7 +2,8 @@
 
 p,
 li,
-address {
+address,
+table {
   font-size: 1.25em;
   margin-top: 0;
   margin-bottom: 1.3em;
@@ -27,7 +28,7 @@ h3,
 header,
 footer,
 .nav,
-thead {
+table {
   font-family: 'Strait', sans-serif;
 }
 

--- a/index.html
+++ b/index.html
@@ -93,17 +93,19 @@ layout: default
     </thead>
     <tbody>
       <tr>
-        <td><strong>I'm paying my own way</strong> &mdash; choose this ticket price if you are paying for your ticket.</td>
-        <td class="text-right"><span class="show-mobile">Early bird (ends 9/25):</span> $60</td>
-        <td class="text-right"><span class="show-mobile">Regular:</span> $90</td>
-      </tr>
-      <tr>
-        <td><strong>My company is paying my way</strong> &mdash; choose this ticket price if your company or another organization is paying for your ticket or will be reimbursing you for your ticket.</td>
+        <td><strong>Full-price ticket</strong></td>
         <td class="text-right"><span class="show-mobile">Early bird (ends 9/25):</span> $120</td>
         <td class="text-right"><span class="show-mobile">Regular:</span> $180</td>
       </tr>
+      <tr>
+        <td><strong>Half-price ticket</strong></td>
+        <td class="text-right"><span class="show-mobile">Early bird (ends 9/25):</span> $60</td>
+        <td class="text-right"><span class="show-mobile">Regular:</span> $90</td>
+      </tr>
     </tbody>
   </table>
+  <p>Choose the <strong>Full-price ticket</strong> if your company is paying for you to attend or will be reimbursing you, or if you're able to pay the full-price. Part of your ticket price will help support women to attend this conference that cannot select this option.<p>
+  <p>Choose the <strong>Half-price ticket</strong> if you’re a student, paying your own way, unemployed or transitioning between jobs. We have this ticket price to help keep the cost of this conference affordable for all women.<p>
 </section>
 
 <!-- ///////////////////////////////////////////////////// -->


### PR DESCRIPTION
I updated the ticket names and descriptions on the site (and in the nvite modal):

![image](https://cloud.githubusercontent.com/assets/2180540/9805676/ff24287a-5809-11e5-8a29-aa936834ce3e.png)


:sparkles: :sparkles: :sparkles: