### PR TITLE
remove Elanor Community from Code of Conduct && copy edits

### DIFF
--- a/code-of-conduct/index.md
+++ b/code-of-conduct/index.md
@@ -2,15 +2,15 @@
 layout: page
 title: Code of Conduct
 ---
-All attendees, speakers, sponsors and volunteers at our events and throughout a mentorship are required to agree with the following code of conduct. Organizers will enforce this code throughout the events and for the duration of a mentorship. We are expecting cooperation from all participants to help ensure a safe environment for everybody.
+All attendees, speakers, sponsors, and volunteers at {{site.title}} and throughout a mentorship are required to agree with the following code of conduct. Organizers will enforce this code throughout {{site.title}} and for the duration of a mentorship. We are expecting cooperation from all participants to help ensure a safe environment for everybody.
 
 ## Need Help?
 
-The Elanor Community email is [hello@elanor.community](mailto:hello@elanor.community) and the {{site.title}} email is [{{site.email}}](mailto:{{site.email}}). Relevant phone numbers will be shared prior to each event and during the mentorship matching phase.
+The {{site.title}} email is [{{site.email}}](mailto:{{site.email}}). Relevant phone numbers will be shared before the conference and during the mentorship matching phase.
 
 ## The Quick Version
 
-Our events, including {{site.title}}, and programs are dedicated to providing a harassment-free experiences for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, or religion (or lack thereof). We do not tolerate harassment of participants in any form. Sexual language and imagery is not appropriate for any event, including conferences, talks, workshops, parties, Twitter and other online media, throughout the duration of a mentorship. Participants violating these rules may be sanctioned or expelled from the Elanor Community *without a refund* (when applicable) at the discretion of the group organizers.
+{{site.title}} is dedicated to providing harassment-free experiences for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, or religion (or lack thereof). We do not tolerate harassment of participants in any form. Sexual language and imagery are not appropriate for any event, including conferences, talks, workshops, parties, Twitter and other online media, throughout the duration of the conference and a mentorship. Participants violating these rules may be sanctioned or expelled from {{site.title}} *without a refund* (when applicable) at the discretion of the group organizers.
 
 ## The Less Quick Version
 
@@ -18,14 +18,14 @@ Harassment includes offensive verbal comments related to gender, gender identity
 
 Participants asked to stop any harassing behavior are expected to comply immediately.
 
-Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualised images, activities, or other material. At events and conferences, booth staff (including volunteers) should not use sexualised clothing/uniforms/costumes, or otherwise create a sexualised environment.
+Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualized images, activities, or other material. At {{site.title}}, sponsors (including volunteers) should not use sexualized clothing/uniforms/costumes, or otherwise, create a sexualized environment.
 
-If a participant engages in harassing behavior, the organizers may take any action they deem appropriate, including warning the offender or expulsion from the event/conference with no refund.
+If a participant engages in harassing behavior, the organizers may take any action they deem appropriate, including warning the offender or expulsion from {{site.title}} with no refund.
 
-If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of staff immediately. Staff will be introduced on the site as well as prior to any event.
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of staff immediately. Staff will be introduced on the site as well as before any event.
 
-Staff will be happy to help participants contact venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance and participation.
+We will help participants contact venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance and participation.
 
-We expect participants, volunteers, mentors, and mentees to follow these rules at all Elanor Community events and programs, including conferences, workshops, social events, and throughout the duration of a mentorship relationship.
+We expect participants, volunteers, mentors, and mentees to follow these rules at all {{site.title}} events and programs, including workshops, social events, and throughout the duration of a mentorship relationship.
 
 *This Code of Conduct was adapted from [The Ada Initiative](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy)*


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/2180540/16859081/c0e4607e-49e0-11e6-95ac-799930f6ac4e.png)

Updated our Code of Conduct to remove references of the Elanor Community and made a few copy edits

Please take a look @jonitrythall @leekinney @ajpeddakotla :)